### PR TITLE
Add loading state for CountryInfo

### DIFF
--- a/src/components/CountryInfo/CountryInfo.tsx
+++ b/src/components/CountryInfo/CountryInfo.tsx
@@ -2,7 +2,15 @@ import { useEffect, useState } from 'react'
 import Markdown from 'markdown-to-jsx'
 
 import { Close } from '@mui/icons-material'
-import { AppBar, Dialog, DialogContent, IconButton, Toolbar, Typography } from '@mui/material'
+import {
+  AppBar,
+  CircularProgress,
+  Dialog,
+  DialogContent,
+  IconButton,
+  Toolbar,
+  Typography,
+} from '@mui/material'
 
 import { Countries } from 'types'
 import { useLocale, useActiveCountryName, useSetActiveCountryName } from 'contexts'
@@ -16,6 +24,7 @@ export const CountryInfo: React.FC = () => {
   const locale = useLocale()
   const activeCountryName = useActiveCountryName()
   const setActiveCountryName = useSetActiveCountryName()
+  const [isLoading, setIsLoading] = useState(true)
   const [countryMd, setCountryMd] = useState('')
   const { emptyMd } = useEmptyMd()
 
@@ -30,12 +39,14 @@ export const CountryInfo: React.FC = () => {
             .then((res) => setCountryMd(res))
             .catch((err) => console.log(err))
         })
+        .finally(() => setIsLoading(false))
         .catch((err) => console.log(err))
     }
   })
 
   useEffect(() => {
     setCountryMd('')
+    setIsLoading(true)
   }, [activeCountryName, locale])
 
   if (!activeCountryName) {
@@ -65,7 +76,7 @@ export const CountryInfo: React.FC = () => {
         </Toolbar>
       </AppBar>
       <DialogContent>
-        <Markdown>{countryMd || emptyMd}</Markdown>
+        {isLoading ? <CircularProgress /> : <Markdown>{countryMd || emptyMd}</Markdown>}
       </DialogContent>
     </Dialog>
   )

--- a/src/components/CountryInfo/CountryInfo.tsx
+++ b/src/components/CountryInfo/CountryInfo.tsx
@@ -37,9 +37,9 @@ export const CountryInfo: React.FC = () => {
           fetch(response.default)
             .then((res) => res.text())
             .then((res) => setCountryMd(res))
+            .finally(() => setIsLoading(false))
             .catch((err) => console.log(err))
         })
-        .finally(() => setIsLoading(false))
         .catch((err) => console.log(err))
     }
   })


### PR DESCRIPTION
We import markdown files lazily via `fetch`, so there might be some noticeable frames when we display `empty.md` until the requested markdown file is ready